### PR TITLE
move contact section button text definition to frontmatter field

### DIFF
--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'Get In Touch'
+buttonText: 'Say Hello'
 ---
 
 Although I'm not currently looking for freelance opportunities, my inbox is always open. Whether for a potential project or just to say hi, I'll try my best to answer your email!

--- a/src/components/sections/contact.js
+++ b/src/components/sections/contact.js
@@ -45,7 +45,7 @@ const StyledEmailLink = styled.a`
 
 const Contact = ({ data }) => {
   const { frontmatter, html } = data[0].node;
-  const { title } = frontmatter;
+  const { title, buttonText } = frontmatter;
   const revealContainer = useRef(null);
   useEffect(() => sr.reveal(revealContainer.current, srConfig()), []);
 
@@ -58,7 +58,7 @@ const Contact = ({ data }) => {
       <div dangerouslySetInnerHTML={{ __html: html }} />
 
       <StyledEmailLink href={`mailto:${email}`} target="_blank" rel="nofollow noopener noreferrer">
-        Say Hello
+        {buttonText}
       </StyledEmailLink>
     </StyledContainer>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -126,6 +126,7 @@ export const pageQuery = graphql`
         node {
           frontmatter {
             title
+            buttonText
           }
           html
         }


### PR DESCRIPTION
Hey Brittany!
I've started to use your Gatsby starter to build my portfolio. So first of all: thx a lot, it's just awesome!

This pull request moves the definition of the contact section button text to a frontmatter field, so it's not hardcoded anymore.

all the best, Manuel