### PR TITLE
Added title to Post Template

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Layout } from '@components';
 import styled from 'styled-components';
 import { Main, theme } from '@styles';
+import Helmet from 'react-helmet';
 const { colors } = theme;
 
 const StyledPostContainer = styled(Main)`
@@ -40,6 +41,9 @@ const PostTemplate = ({ data, location }) => {
 
   return (
     <Layout location={location}>
+      <Helmet>
+        <title>{title} | Pensieve | Brittany Chiang</title>
+      </Helmet>
       <StyledPostContainer>
         <span className="breadcrumb">
           <span className="arrow">&larr;</span>


### PR DESCRIPTION
The `<title>` of post pages must have the name of the post, which improves SEO. This commit adds the title of the post followed by Pensive and the name, to the title of the web page.