### PR TITLE
Use a larger tab height and normal text wrapping to display long company name on mobile

### DIFF
--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -32,6 +32,16 @@ const StyledTabList = styled.div`
   margin: 0;
   list-style: none;
 
+  /* hide scrollbar but allow scrolling */
+  // https://blog.hubspot.com/website/hide-scrollbar-css
+  -ms-overflow-style: none; /* for Internet Explorer, Edge */
+  scrollbar-width: none; /* for Firefox */
+  overflow-y: scroll;
+
+  &::-webkit-scrollbar {
+    display: none; /* for Chrome, Safari, and Opera */
+  }
+
   @media (max-width: 600px) {
     display: flex;
     overflow-x: auto;

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -91,6 +91,8 @@ const StyledTabButton = styled.button`
     border-left: 0;
     border-bottom: 2px solid var(--lightest-navy);
     text-align: center;
+    white-space: normal;
+    height: var(--tab-height-mobile);
   }
 
   &:hover,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -32,6 +32,7 @@ const variables = css`
     --nav-scroll-height: 70px;
 
     --tab-height: 42px;
+    --tab-height-mobile: 60px;
     --tab-width: 120px;
 
     --easing: cubic-bezier(0.645, 0.045, 0.355, 1);


### PR DESCRIPTION
In the jobs section, long company names don't display well on mobile so I attempted a fix.

My site before the fix:
<img width="400" alt="Screen Shot 2021-06-18 at 17 02 36" src="https://user-images.githubusercontent.com/35674052/122630599-c59db780-d079-11eb-9feb-d7bf789bfb4b.png">

After:
<img width="400" alt="Screen Shot 2021-06-18 at 21 03 45" src="https://user-images.githubusercontent.com/35674052/122630601-c8001180-d079-11eb-87ed-a8406010b539.png">