### PR TITLE
Barcos.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Yes, you can fork this repo. Please give me proper credit by linking back to [br
    npm run serve
    ```
 
+1. Start with pm2
+
+   ```
+   pm2 --name SOME_NAME start npm -- run serve
+   ```
+
 ## 🎨 Color Reference
 
 | Color          | Hex                                                                |

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Yes, you can fork this repo. Please give me proper credit by linking back to [br
    npm run serve
    ```
 
-1. Start with pm2
+1. Start with pm2. Make sure you have pm2 installed. [How to install pm2](https://medium.com/idomongodb/how-to-npm-run-start-at-the-background-%EF%B8%8F-64ddda7c1f1)
 
-   ```
+   ```sh
    pm2 --name SOME_NAME start npm -- run serve
    ```
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --host=0.0.0.0",
     "clean": "gatsby clean",
     "prepare": "husky install",
     "lint-staged": "lint-staged"


### PR DESCRIPTION
1. Adding localhost and local_ip support

When trying to run the gatsby server on a VM is mandatory to set the localhost flag. Whit this flag set to 0.0.0.0 we are able to reach the app on `http://localhost:PORT` and `http://LOCAL_IP:PORT`.

Taken from https://www.gatsbyjs.com/docs/tutorial/part-1/#run-your-site-locally

> Note: If you are using VM setup like vagrant and/or would like to listen on your local IP address, run gatsby develop --host=0.0.0.0. Now, the development server listens on both http://localhost and your local IP.

2. Adding pm2 execution command example for background mode 