### PR TITLE
add :focus-visible global styles with polyfill

### DIFF
--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -24,7 +24,27 @@ const GlobalStyle = createGlobalStyle`
     color: var(--lightest-slate);
   }
 
+  /* Provide basic, default focus styles.*/
   :focus {
+    outline: 2px dashed var(--green);
+    outline-offset: 3px;
+  }
+
+  /*
+    Remove default focus styles for mouse users ONLY if
+    :focus-visible is supported on this platform.
+  */
+  :focus:not(:focus-visible) {
+    outline: none;
+    outline-offset: 0px;
+  }
+
+  /*
+    Optionally: If :focus-visible is supported on this
+    platform, provide enhanced focus styles for keyboard
+    focus.
+  */
+  :focus-visible {
     outline: 2px dashed var(--green);
     outline-offset: 3px;
   }


### PR DESCRIPTION
## Description
You already have a default `:focus` style in `GlobalStyle.js`. This PR adds the new [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) style, which only adds focus styles when the user navigates with the keyboard, not the mouse.

## Screenshots

### Before

![Kapture 2021-10-04 at 15 50 49](https://user-images.githubusercontent.com/21218732/135834899-29d193ad-554c-4e3a-9b97-7a80d1949249.gif)
### After

![Kapture 2021-10-04 at 15 52 21](https://user-images.githubusercontent.com/21218732/135835083-e020e0d9-ea5f-436b-89ce-99945def820c.gif)
## References

1. [WICG/focus-visible](https://github.com/WICG/focus-visible#backwards-compatibility)
2. [`:focus-visible` and backwards compatibility](https://www.tpgi.com/focus-visible-and-backwards-compatibility/)

## Live Test

I use [these styles](https://github.com/gupta-ji6/ayushgupta.tech/blob/8cf885b369e6c2addf71021af0b8cb7fc09d9b0d/src/styles/GlobalStyle.js#L141-L154) in my [portfolio](https://ayushgupta.tech), you can test how this works here for a quick look.

## P.S.

Thank you for building such a great portfolio and open souring it :)
I totally understand if these changes don't suit your needs. I raised a PR thinking it might be a good add-on. I will happy to if I contributed to something I have been using myself for a long time.

