### PR TITLE
Minor StyledPic hover fix

### DIFF
--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -65,7 +65,6 @@ const StyledPic = styled.div`
 
     &:hover,
     &:focus {
-      background: transparent;
       outline: 0;
 
       &:after {


### PR DESCRIPTION
Fixed a minor StyledPic hover issue.
When the cursor is dragged away from the image in "About Me" section, it turns abruptly black for an instant.
This minor code fix shows smooth transition back to un-hovered state.