### PR TITLE
BUG FIXED: Project card when only one link(github)

### DIFF
--- a/src/components/sections/projects.js
+++ b/src/components/sections/projects.js
@@ -242,7 +242,7 @@ const Projects = () => {
           </div>
 
           <h3 className="project-title">
-            <a href={external} target="_blank" rel="noreferrer">
+            <a href={external || github} target="_blank" rel="noreferrer">
               {title}
             </a>
           </h3>


### PR DESCRIPTION
## There was a BUG; now FIXED.
**Scenario:** When there is only one link e.g. GitHub(other than an external link), if one clicks the project card, one will get redirected to the original site in a new tab.

<img width="1611" alt="ss" src="https://github.com/bchiang7/v4/assets/80618762/bc814a6e-6567-45af-a1e8-951a6534560a">
here to the Localhost:9002 
<br> </br>

**Solution:** Add ` || github`  just after external in href in the line no. 245 at src/components/sections/projects.js
<img width="872" alt="sol" src="https://github.com/bchiang7/v4/assets/80618762/6993b1c9-8388-4631-a33d-ebd59825d822">
