### PR TITLE
fix: correct hex color placeholders in README palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Yes, you can fork this repo. Please give me proper credit by linking back to [br
 
 | Color          | Hex                                                                |
 | -------------- | ------------------------------------------------------------------ |
-| Navy           | ![#0a192f](https://via.placeholder.com/10/0a192f?text=+) `#0a192f` |
-| Light Navy     | ![#112240](https://via.placeholder.com/10/0a192f?text=+) `#112240` |
-| Lightest Navy  | ![#233554](https://via.placeholder.com/10/303C55?text=+) `#233554` |
-| Slate          | ![#8892b0](https://via.placeholder.com/10/8892b0?text=+) `#8892b0` |
-| Light Slate    | ![#a8b2d1](https://via.placeholder.com/10/a8b2d1?text=+) `#a8b2d1` |
-| Lightest Slate | ![#ccd6f6](https://via.placeholder.com/10/ccd6f6?text=+) `#ccd6f6` |
-| White          | ![#e6f1ff](https://via.placeholder.com/10/e6f1ff?text=+) `#e6f1ff` |
-| Green          | ![#64ffda](https://via.placeholder.com/10/64ffda?text=+) `#64ffda` |
+| Navy           | ![#0a192f](https://placehold.co/10x10/0a192f/0a192f.png) `#0a192f` |
+| Light Navy     | ![#112240](https://placehold.co/10x10/112240/112240.png) `#112240` |
+| Lightest Navy  | ![#233554](https://placehold.co/10x10/233554/233554.png) `#233554` |
+| Slate          | ![#8892b0](https://placehold.co/10x10/8892b0/8892b0.png) `#8892b0` |
+| Light Slate    | ![#a8b2d1](https://placehold.co/10x10/a8b2d1/a8b2d1.png) `#a8b2d1` |
+| Lightest Slate | ![#ccd6f6](https://placehold.co/10x10/ccd6f6/ccd6f6.png) `#ccd6f6` |
+| White          | ![#e6f1ff](https://placehold.co/10x10/e6f1ff/e6f1ff.png) `#e6f1ff` |
+| Green          | ![#64ffda](https://placehold.co/10x10/64ffda/64ffda.png) `#64ffda` |


### PR DESCRIPTION
Noticed the README color previews were off.
Replaced the placeholder links and corrected the hex mappings so the palette renders properly.
